### PR TITLE
Update dashboard domain reference to auth.burnt.com

### DIFF
--- a/.changeset/six-zebras-impress.md
+++ b/.changeset/six-zebras-impress.md
@@ -2,4 +2,4 @@
 "@burnt-labs/constants": minor
 ---
 
-Transition from dashboard.burnt.com to settings.burnt.com to help us ready for splitting the dashboard apart
+Transition from dashboard.burnt.com to auth.burnt.com to help us ready for splitting the dashboard apart


### PR DESCRIPTION
## Summary

Update the remaining dashboard-domain changeset reference from `settings.burnt.com` to `auth.burnt.com`.

## Impact

The workspace no longer carries the retired settings hostname in its tracked changeset metadata.

## Validation

- verified no tracked `settings.burnt.com` or `settings.testnet.burnt.com` references remain
- `git diff --check`